### PR TITLE
Update the doc about the builder address

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ process is passed successfully.
 
 You can check and build the docs by yourself on your machine using a
 [custom
-dockerimage](https://hub.docker.com/r/dancn/guided-tour-builder/) by
+dockerimage](https://hub.docker.com/r/smartsdk/guided-tour-builder/) by
 running the following command in the root directory of the project:
 
 ``` shell
-docker run -it --rm -v "$(pwd):/docs" dancn/guided-tour-builder
+docker run -it --rm -v "$(pwd):/docs" smartsdk/guided-tour-builder
 ```
 
 Should you have a solution yourself, feel free to make a pull request!


### PR DESCRIPTION
The repo and image are now under the smartsdk namespace.