### PR TITLE
Additional note when using env variables with sudo

### DIFF
--- a/docs/platform/deployservices.md
+++ b/docs/platform/deployservices.md
@@ -100,7 +100,8 @@ $ source settings.env
 $ docker stack deploy -c docker-compose.yml ${STACK_NAME}
 ```
 
-NOTE: When executing docker with `sudo` it is necesary to pass the environment variables set previously by using the `-E` flag. ie. 
+NOTE: When executing docker with `sudo` it is necesary to pass the environment
+variables set previously by using the `-E` flag. ie. 
 ```
 $ sudo -E docker stack deploy -c docker-compose.yml ${STACK_NAME}
 ```

--- a/docs/platform/deployservices.md
+++ b/docs/platform/deployservices.md
@@ -100,6 +100,11 @@ $ source settings.env
 $ docker stack deploy -c docker-compose.yml ${STACK_NAME}
 ```
 
+NOTE: When executing docker with `sudo` it is necesary to pass the environment variables set previously by using the `-E` flag. ie. 
+```
+$ sudo -E docker stack deploy -c docker-compose.yml ${STACK_NAME}
+```
+
 In Windows...
 
 ```
@@ -427,7 +432,7 @@ and Orion Context Broker deployed following this guide.
 
 ```
 $ cd iot-services/iotagent-ul
-$ docker stack deploy -c docker-compose iota-ul
+$ docker stack deploy -c docker-compose.yml iota-ul
 ```
 
 You can check the agent started properly by checking the replicas are up and

--- a/docs/platform/deployservices.md
+++ b/docs/platform/deployservices.md
@@ -101,7 +101,8 @@ $ docker stack deploy -c docker-compose.yml ${STACK_NAME}
 ```
 
 NOTE: When executing docker with `sudo` it is necesary to pass the environment
-variables set previously by using the `-E` flag. ie. 
+variables set previously by using the `-E` flag. ie.
+
 ```
 $ sudo -E docker stack deploy -c docker-compose.yml ${STACK_NAME}
 ```


### PR DESCRIPTION
By running docker with sudo, a problem raised when mongo-controller call mongo sets due to missing environment variables. It is needed to pass the -E flag to set the env variables when being superuser. + a small typo in docker-compose.yml command